### PR TITLE
fix: 移除不必要的 Manifest 声明

### DIFF
--- a/builtinftp/src/main/AndroidManifest.xml
+++ b/builtinftp/src/main/AndroidManifest.xml
@@ -6,9 +6,7 @@
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
   <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
   <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
-  <application android:largeHeap="true" android:allowBackup="true" android:supportsRtl="true" android:requestLegacyExternalStorage="true">
+  <application android:largeHeap="true" android:allowBackup="true" android:requestLegacyExternalStorage="true">
     <uses-library android:name="org.apache.http.legacy" android:required="false"/>
-    <activity android:name=".AutoRunSettingsActivity" android:theme="@android:style/Theme.Holo.Light"/>
-    <activity android:name=".ApplicationFrequencySettingsActivity" android:theme="@android:style/Theme.Holo.Light"/>
   </application>
 </manifest>


### PR DESCRIPTION
## 问题描述
集成 `ftpserver` 库后，主应用的 AI 消息文本意外靠右对齐。

## 根本原因
`ftpserver/builtinftp/src/main/AndroidManifest.xml` 中包含：
- `android:supportsRtl="true"` - 激活了主应用布局文件中原本被忽略的 `textAlignment` 属性
- 2 个未使用的 Activity 声明（无对应 Java 源文件）

作为纯功能库（FTP 服务器），不应声明 UI 相关的全局属性。

## 修复内容
修改 `builtinftp/src/main/AndroidManifest.xml`：
1. **删除** `android:supportsRtl="true"` 属性
2. **删除** `<activity android:name=".AutoRunSettingsActivity" .../>`
3. **删除** `<activity android:name=".ApplicationFrequencySettingsActivity" .../>`

## 影响评估
✅ **正面影响**：
- 防止库的 Manifest 属性污染主应用
- 避免类似的布局问题再次发生
- 符合库的最佳实践（功能库不应声明 UI 相关属性）

⚠️ **潜在风险**：无
- 已确认没有任何项目使用这 2 个 Activity
- `supportsRtl` 对 FTP 服务器功能无影响

## 测试建议
1. 发布新版本（如 `2026.1.30`）
2. 更新 `sisterfuture` 项目的 `builtinftp` 依赖
3. 验证主应用 UI 布局正常
4. 验证 FTP 服务器功能正常

## 相关文件
- `builtinftp/src/main/AndroidManifest.xml`