### PR TITLE
Debug: Add LIST response content logging to DirectoryListSender

### DIFF
--- a/builtinftp/src/main/java/com/stupidbeauty/ftpserver/lib/DirectoryListSender.java
+++ b/builtinftp/src/main/java/com/stupidbeauty/ftpserver/lib/DirectoryListSender.java
@@ -217,6 +217,7 @@ public class DirectoryListSender
     if (photoDirecotry.isFile())  // 是一个文件。
     {
       String currentLine = construct1LineListFile(photoDirecotry, photoDirecotry.getName()); // 构造针对这个文件的一行输出。
+        Log.d(TAG, "DirectoryListSender [Single File], sending line: [" + currentLine + "]"); // Debug
       binaryStringSender.sendStringInBinaryMode(currentLine); // 发送回复内容。
     }
     else  // 是目录
@@ -233,6 +234,7 @@ public class DirectoryListSender
           String placeholderLine = "-rw-r--r-- 1 user group 0 Jan 01 00:00 .dolphin_placeholder\r\n";
           binaryStringSender.sendStringInBinaryMode(placeholderLine);
         }
+          Log.d(TAG, "DirectoryListSender [Empty Dir], sending placeholder line: [" + placeholderLine + "]"); // Debug
       }
       else  // 列出成功
       {
@@ -291,6 +293,7 @@ public class DirectoryListSender
 
           if (fileName.equals(nameOfFile) || nameOfFile.isEmpty())  // 匹配或全部列出
           {
+            Log.d(TAG, "DirectoryListSender [Dir Loop], sending line: [" + currentLine + "]"); // Debug
             binaryStringSender.sendStringInBinaryMode(currentLine); // 发送当前行
           }
         }


### PR DESCRIPTION
## Debug Commit for FTP LIST Response Compatibility Issue

### 问题描述
Apache FTPClient 无法正确解析内置 ftpserver 的 LIST 命令响应，导致 `listFiles()` 返回空数组。

### 修改内容
在 `DirectoryListSender.java` 的三个发送位置添加调试日志，输出实际发送的每一行内容：

1. **单文件模式**（Single File）：
   ```java
   Log.d(TAG, "DirectoryListSender [Single File], sending line: [" + currentLine + "]"); // Debug
   ```

2. **目录遍历模式**（Dir Loop）：
   ```java
   Log.d(TAG, "DirectoryListSender [Dir Loop], sending line: [" + currentLine + "]"); // Debug
   ```

3. **空目录占位符**（Empty Dir）：
   ```java
   Log.d(TAG, "DirectoryListSender [Empty Dir], sending placeholder line: [" + placeholderLine + "]"); // Debug
   ```

### 目的
通过日志输出，确认 ftpserver 实际发送的 LIST 响应格式（是否包含权限、用户、组、大小、日期等元数据），以便诊断 Apache FTPClient 解析失败的根本原因。

### 使用方式
1. 编译安装带有此修改的 APP
2. 使用 `adb logcat | grep "DirectoryListSender"` 过滤日志
3. 观察实际发送的每一行内容格式

### 注意事项
- 这是一个纯调试提交，不涉及任何逻辑改动
- 日志标签为 `DirectoryListSender`，便于过滤
- 调试完成后可选择合并或丢弃此分支